### PR TITLE
What percentage of invoices are not shipped?

### DIFF
--- a/spec/iteration_2_spec.rb
+++ b/spec/iteration_2_spec.rb
@@ -170,10 +170,6 @@ RSpec.describe "Iteration 2" do
       expected = sales_analyst.invoice_status(:shipped)
 
       expect(expected).to eq 56.95
-
-      expected = sales_analyst.invoice_status(:returned)
-
-      expect(expected).to eq 13.5
     end
   end
 end


### PR DESCRIPTION
The spec calls for a comparison of pending vs. shipped while the current spec harness compares shipped vs. pending vs. returned

We specifically did the calculation to show pending versus shipped. Please let us know if this is the incorrect interpretation

Thank you - Allan / Brennan
