### PR TITLE
Update iteration_2_spec.rb

### DIFF
--- a/spec/iteration_2_spec.rb
+++ b/spec/iteration_2_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "Iteration 2" do
       expect(expected.first.class).to eq Merchant
     end
 
-    it "#top_days_by_invoice_count returns invoices with an invoice item count more than two standard deviations above the mean" do
+    it "#top_days_by_invoice_count returns invoices with an invoice item count more than one standard deviation above the mean" do
       expected = sales_analyst.top_days_by_invoice_count
 
       expect(expected.length).to eq 1


### PR DESCRIPTION
top days should return those above one std deviation, not two. The expected value is correct for one std dev above. If the method is actually for two standard deviations above the mean, then the expectation should be: expect(expected.length).to eq 0
