### PR TITLE
top_days_by_invoice_count & merchant_customer_relationship

### DIFF
--- a/spec/iteration_1_spec.rb
+++ b/spec/iteration_1_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Iteration 1" do
     end
 
     it "#average_average_price_per_merchant returns the average price for all merchants" do
-      expected = sales_analyst.average_average_price_per_merchant
+      expected = sales_analyst.average_price_per_merchant
 
       expect(expected).to eq 349.56
       expect(expected.class).to eq BigDecimal

--- a/spec/iteration_1_spec.rb
+++ b/spec/iteration_1_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Iteration 1" do
     end
 
     it "#average_average_price_per_merchant returns the average price for all merchants" do
-      expected = sales_analyst.average_price_per_merchant
+      expected = sales_analyst.average_average_price_per_merchant
 
       expect(expected).to eq 349.56
       expect(expected.class).to eq BigDecimal

--- a/spec/iteration_2_spec.rb
+++ b/spec/iteration_2_spec.rb
@@ -155,11 +155,11 @@ RSpec.describe "Iteration 2" do
       expect(expected.first.class).to eq Merchant
     end
 
-    it "#top_days_by_invoice_count returns invoices with an invoice item count more than one standard deviation above the mean" do
+    it "#top_days_by_invoice_count returns days with an invoice count more than one standard deviation above the mean" do
       expected = sales_analyst.top_days_by_invoice_count
 
       expect(expected.length).to eq 1
-      expect(expected.first.class).to eq Symbol
+      expect(expected.first.class).to eq String
     end
 
     it "#invoice_status returns the percentage of invoices with given status" do

--- a/spec/iteration_3_spec.rb
+++ b/spec/iteration_3_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe "Iteration 3" do
     it "merchant#customers returns related customers" do
       expected = engine.merchants.find_by_id(12334194).customers
 
-      expect(expected.length).to eq 13
+      expect(expected.length).to eq 12
       expect(expected.first.class).to eq Customer
     end
   end


### PR DESCRIPTION
For top_days_by_invoice_count:
  -the spec shows this method like this:

  `sa.top_days_by_invoice_count # => ["Sunday", "Saturday"]`

For merchant_customer_relationship:
  -13 should be 12 because one of the customers is a repeat:

![customer_array](https://cloud.githubusercontent.com/assets/13652979/12385342/6b1e1300-bd78-11e5-87cd-41b1040c8991.jpg)
![merchant_customer_relationship](https://cloud.githubusercontent.com/assets/13652979/12385338/6188ebd0-bd78-11e5-8bc7-5cce4a9ba5a2.jpg)
