### PR TITLE
Changing the date in revenue by date

### DIFF
--- a/spec/iteration_4_spec.rb
+++ b/spec/iteration_4_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Iteration 4" do
 
   context "Sales Analyst - Merchant Repository" do
     it "#total_revenue_by_date returns total revenue for given date" do
-      date = Time.parse("2011-02-27")
+      date = Time.parse("2009-02-07")
       expected = sales_analyst.total_revenue_by_date(date)
 
       expect(expected).to eq 13010.46


### PR DESCRIPTION
It seems this is by `updated_at` when most are doing this by `created_at` we have changed this date to a `created_at` date in the invoice.csv!

Best - Allan / Brennan
