### PR TITLE
Corrected one_time_buyers_item description and method name

### DIFF
--- a/spec/iteration_5_spec.rb
+++ b/spec/iteration_5_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe "iteration 5" do
       expect(expected.first.class).to eq Customer
     end
 
-    it "#one_time_buyers_top_items returns all the items which one_time_buyers bought" do
-      expected = sales_analyst.one_time_buyers_top_items
+    it "#one_time_buyers_item returns the item which most one_time_buyers bought" do
+      expected = sales_analyst.one_time_buyers_item
 
       expect(expected.length).to eq 1
       expect(expected.map(&:id)).to eq [263518806]


### PR DESCRIPTION
Fixed spec harness iter5 to match spec.